### PR TITLE
Use 5.0.2 everywhere instead of 5.0.0 or 5.0.1

### DIFF
--- a/examples/quick-start/QuickStart.wixproj
+++ b/examples/quick-start/QuickStart.wixproj
@@ -1,2 +1,2 @@
-<Project Sdk="WixToolset.Sdk/5.0.1">
+<Project Sdk="WixToolset.Sdk/5.0.2">
 </Project>

--- a/src/content/docs/heatwave/build-tools/harvesting/index.md
+++ b/src/content/docs/heatwave/build-tools/harvesting/index.md
@@ -11,13 +11,13 @@ Harvesting is controlled by extension elements, `<HarvestProjectOutput/>` and `<
 The parent element will act as the template for the harvesting. Let's look at a very simple example. Consider a *SetupProject1.wixproj* with a project reference to *ConsoleApplication1.csproj* which in turn has a project reference to *ClassLibrary1.csproj*. In *SetupProject1.wixproj*, list the outputs we want to harvest from the project by adding `HarvestOutputGroup` metadata. In this example, we'll harvest the build outputs and dependencies of *ConsoleApplication1.csproj*:
 
 ```xml title=SetupProject1.wixproj
-<Project Sdk="WixToolset.Sdk/5.0.1">
+<Project Sdk="WixToolset.Sdk/5.0.2">
   <ItemGroup>
     <ProjectReference Include="..\ConsoleApplication1\ConsoleApplication1.csproj" HarvestOutputGroup="BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FireGiant.HeatWave.BuildTools.wixext" Version="5.0.1" />
+    <PackageReference Include="FireGiant.HeatWave.BuildTools.wixext" Version="5.0.2" />
   </ItemGroup>
 </Project>
 ```

--- a/src/content/docs/wix/tools/msbuild.md
+++ b/src/content/docs/wix/tools/msbuild.md
@@ -5,7 +5,7 @@ title: MSBuild
 WiX v4 is available as an MSBuild SDK. SDK-style projects have smart defaults that make for simple .wixproj project authoring. For example, here's a minimal .wixproj that builds an MSI from the .wxs source files in the project directory:
 
 ```xml
-<Project Sdk="WixToolset.Sdk/5.0.0">
+<Project Sdk="WixToolset.Sdk/5.0.2">
 </Project>
 ```
 
@@ -141,7 +141,7 @@ You can then reference `MyProductNameProperty`, for example, in other properties
 To make property values available as preprocessor variables in your WiX authoring, add them to the `DefineConstants` property. For example:
 
 ```xml
-<Project Sdk="WixToolset.Sdk/5.0.0">
+<Project Sdk="WixToolset.Sdk/5.0.2">
   <PropertyGroup Label="Globals">
      <DefineConstants>MyProductNameProperty=$(MyProductNameProperty);</DefineConstants>
   </PropertyGroup>

--- a/src/content/docs/wix/tools/wixexe.md
+++ b/src/content/docs/wix/tools/wixexe.md
@@ -252,7 +252,7 @@ Manage the extension cache. Extensions are referenced by:
 - `id` (uses the latest available version)
 
 :::note
-When omitting `version`, `wix extension` commands could choose a version of an extension that is incompatible with the version of WiX you're running. Use a specific version to avoid that scenario. For example: `wix extension add WixToolset.Util.wixext/5.0.0`
+When omitting `version`, `wix extension` commands could choose a version of an extension that is incompatible with the version of WiX you're running. Use a specific version to avoid that scenario. For example: `wix extension add WixToolset.Util.wixext/5.0.2`
 :::
 
 | Subcommand | Description |

--- a/src/content/docs/wix/using-wix.md
+++ b/src/content/docs/wix/using-wix.md
@@ -28,7 +28,7 @@ SDK-style projects have smart defaults that make for simple .wixproj project aut
 For example, here's a minimal .wixproj that builds an MSI from the .wxs source files in the project directory:
 
 ```xml
-<Project Sdk="WixToolset.Sdk/5.0.1">
+<Project Sdk="WixToolset.Sdk/5.0.2">
 </Project>
 ```
 
@@ -37,7 +37,7 @@ For example, here's a minimal .wixproj that builds an MSI from the .wxs source f
 To update your .wixproj MSBuild projects from previous WiX releases, update the `Project` element's `Sdk` attribute:
 
 ```xml
-<Project Sdk="WixToolset.Sdk/5.0.1">
+<Project Sdk="WixToolset.Sdk/5.0.2">
 ```
 
 For `PackageReference`s to WiX extensions, update their `Version` attribute. For example:


### PR DESCRIPTION
I noticed, that some of the code snippets referenced WiX 5.0.0 or 5.0.1 and thought to update them all to the latest version 5.0.2