### PR TITLE
Add basic GitHub Actions steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build Docs
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup PNPM
+      uses: pnpm/action-setup@v4
+      with:
+        version: latest
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+    - name: Install
+      run: pnpm install
+    - name: Build
+      run: pnpm build


### PR DESCRIPTION
This is just a very basic CI step to ensure that pushes/PRs actually build.

Not sure if the Node v22 is what you're currently targeting.

An alternative, would also be to use the [withastro/action](https://github.com/withastro/action/blob/main/action.yml) which packages the whole contents as well and prepares it for deployment to GitHub Pages. See also [my branch](https://github.com/eXpl0it3r/docs/blob/feature/github-actions-withastro/.github/workflows/build.yml) for that.