### PR TITLE
Clean up some of the conditional examples

### DIFF
--- a/src/content/docs/wix/tools/preprocessor.md
+++ b/src/content/docs/wix/tools/preprocessor.md
@@ -107,12 +107,12 @@ There are several conditional blocks that let you include or exclude XML based o
 
 | Name | Description |
 | ---- | ----------- |
-| <?if _expression_ ?> | Include the XML fragment if the provided expression evaluates to true. |
-| <?ifdef _variablename_ ?> | Include the XML fragment if the specified variable is defined. |
-| <?ifndef _variablename_ ?> | Include the XML fragment if the specified variable is *not* defined. |
-| <?elseif _expression_ ?> | Include the XML fragment if a preceding `<?if?>`, `<?ifdef?>`, or `<?ifndef?>` block condition wasn't met *and* the provided expression evaluates to true. |
-| <?else?> | Include the XML fragment if _all_ preceding `<?if?>`, `<?ifdef?>`, or `<?ifndef?>` block conditions weren't met. |
-| <?endif?> | Indicates the end of the conditional blocks. |
+| \<?if _expression_ ?> | Include the XML fragment if the provided expression evaluates to true. |
+| \<?ifdef _variablename_ ?> | Include the XML fragment if the specified variable is defined. |
+| \<?ifndef _variablename_ ?> | Include the XML fragment if the specified variable is *not* defined. |
+| \<?elseif _expression_ ?> | Include the XML fragment if a preceding `<?if?>`, `<?ifdef?>`, or `<?ifndef?>` block condition wasn't met *and* the provided expression evaluates to true. |
+| \<?else?> | Include the XML fragment if _all_ preceding `<?if?>`, `<?ifdef?>`, or `<?ifndef?>` block conditions weren't met. |
+| \<?endif?> | Indicates the end of the conditional blocks. |
 
 Conditional blocks always begin with `<?if?>`, `<?ifdef?>`, or `<?ifndef ?>`, followed by optional `<?elseif?>`s and one optional `<?else?>`, and must end with `<?endif?>`:
 
@@ -120,13 +120,13 @@ Conditional blocks always begin with `<?if?>`, `<?ifdef?>`, or `<?ifndef ?>`, fo
 {<?if?>|<?ifdef?>|<?ifndef?>}
   <xml />
   <xml />
-[<?elseif>]
+[<?elseif?>]
   <xml />
   <xml />
-[<?elseif>]
+[<?elseif?>]
   <xml />
   <xml />
-[<?else>]
+[<?else?>]
   <xml />
   <xml />
 <?endif?>


### PR DESCRIPTION
1) Add missing `?` in the close statement
2) Escape the initial `>` in a table to stop markup eating the text

See https://github.com/wixtoolset/issues/issues/9214# and https://github.com/firegiant/docs/pull/18#issuecomment-3711294073